### PR TITLE
TimePlugin

### DIFF
--- a/examples/cubes.cpp
+++ b/examples/cubes.cpp
@@ -1,5 +1,4 @@
 #include "ige.hpp"
-#include <chrono>
 #include <iostream>
 #include <optional>
 
@@ -20,6 +19,8 @@ using ige::ecs::World;
 using ige::plugin::render::MeshRenderer;
 using ige::plugin::render::PerspectiveCamera;
 using ige::plugin::render::RenderPlugin;
+using ige::plugin::time::Time;
+using ige::plugin::time::TimePlugin;
 using ige::plugin::transform::Transform;
 using ige::plugin::transform::TransformPlugin;
 using ige::plugin::window::WindowEvent;
@@ -28,18 +29,12 @@ using ige::plugin::window::WindowPlugin;
 using ige::plugin::window::WindowSettings;
 
 class RootState : public State {
-    using Instant = std::chrono::time_point<std::chrono::steady_clock>;
-
     std::optional<EventChannel<WindowEvent>::Subscription> m_win_events;
 
     std::vector<World::EntityRef> cubes;
 
-    Instant start_time;
-
     void on_start(App& app) override
     {
-        start_time = std::chrono::steady_clock::now();
-
         auto mesh = Mesh::make_cube(1.0f);
         auto material = Material::make_default();
         material->set(
@@ -72,9 +67,7 @@ class RootState : public State {
 
     void on_update(App& app) override
     {
-        Instant now = std::chrono::steady_clock::now();
-        std::chrono::duration<float> dur = now - start_time;
-        float t = dur.count();
+        float t = app.world().get<Time>()->seconds_since_startup();
 
         for (auto cube : cubes) {
             Transform* xform = cube.get_component<Transform>();
@@ -101,6 +94,7 @@ int main()
         .add_plugin(TransformPlugin {})
         .add_plugin(WindowPlugin {})
         .add_plugin(RenderPlugin {})
+        .add_plugin(TimePlugin {})
         .run<RootState>();
 
     std::cout << "Bye bye!" << std::endl;

--- a/examples/gltf.cpp
+++ b/examples/gltf.cpp
@@ -25,6 +25,8 @@ using ige::plugin::gltf::GltfScene;
 using ige::plugin::render::MeshRenderer;
 using ige::plugin::render::PerspectiveCamera;
 using ige::plugin::render::RenderPlugin;
+using ige::plugin::time::Time;
+using ige::plugin::time::TimePlugin;
 using ige::plugin::transform::Transform;
 using ige::plugin::transform::TransformPlugin;
 using ige::plugin::window::WindowEvent;
@@ -38,8 +40,10 @@ struct Rotation {
 
 static void rotation_system(World& world)
 {
+    auto time = world.get<Time>();
+
     for (auto [entity, rot, xform] : world.query<Rotation, Transform>()) {
-        xform.rotate(rot.velocity);
+        xform.rotate(rot.velocity * time->delta_seconds());
     }
 }
 
@@ -55,7 +59,7 @@ class RootState : public State {
         app.world().create_entity(
             Transform::from_pos(vec3(-2.0f, 0.0f, 0.0f)),
             Rotation {
-                vec3(0.0f, 0.2f, 0.0f),
+                vec3(0.0f, 20.0f, 0.0f),
             },
             GltfScene {
                 "assets/BoxTextured.glb",
@@ -65,7 +69,7 @@ class RootState : public State {
         app.world().create_entity(
             Transform::from_pos(vec3(2.0f, 0.0f, 0.0f)).set_scale(0.2f),
             Rotation {
-                vec3(0.0f, 0.2f, 0.0f),
+                vec3(0.0f, 20.0f, 0.0f),
             },
             GltfScene {
                 "assets/OrientationTest.glb",
@@ -94,11 +98,12 @@ int main()
         std::cout << "Starting application..." << std::endl;
         App::Builder()
             .insert(WindowSettings { "Hello, World!", 800, 600 })
-            .add_system(System(rotation_system))
+            .add_plugin(TimePlugin {})
             .add_plugin(GltfPlugin {})
             .add_plugin(TransformPlugin {})
             .add_plugin(WindowPlugin {})
             .add_plugin(RenderPlugin {})
+            .add_system(System(rotation_system))
             .run<RootState>();
         std::cout << "Bye bye!" << std::endl;
     } catch (const std::exception& e) {

--- a/ige/CMakeLists.txt
+++ b/ige/CMakeLists.txt
@@ -80,6 +80,7 @@ set(sources ${sources}
     "include/ige/plugin/input/Mouse.hpp"
     "include/ige/plugin/InputPlugin.hpp"
     "include/ige/plugin/RenderPlugin.hpp"
+    "include/ige/plugin/TimePlugin.hpp"
     "include/ige/plugin/TransformPlugin.hpp"
     "include/ige/plugin/WindowPlugin.hpp"
 
@@ -114,6 +115,7 @@ set(sources ${sources}
     "src/plugin/renderer/opengl/VertexArray.cpp"
     "src/plugin/renderer/opengl/VertexArray.hpp"
     "src/plugin/RenderPlugin.cpp"
+    "src/plugin/TimePlugin.cpp"
     "src/plugin/TransformPlugin.cpp"
     "src/plugin/WindowPlugin.cpp"
 )

--- a/ige/include/ige/plugin.hpp
+++ b/ige/include/ige/plugin.hpp
@@ -4,6 +4,7 @@
 #include "plugin/GltfPlugin.hpp"
 #include "plugin/InputPlugin.hpp"
 #include "plugin/RenderPlugin.hpp"
+#include "plugin/TimePlugin.hpp"
 #include "plugin/TransformPlugin.hpp"
 #include "plugin/WindowPlugin.hpp"
 

--- a/ige/include/ige/plugin/TimePlugin.hpp
+++ b/ige/include/ige/plugin/TimePlugin.hpp
@@ -1,0 +1,34 @@
+#ifndef F86E20B8_2AFA_4597_AD7A_707E4AEA22BC
+#define F86E20B8_2AFA_4597_AD7A_707E4AEA22BC
+
+#include "ige/core/App.hpp"
+#include <chrono>
+
+namespace ige::plugin::time {
+
+class Time {
+private:
+    std::chrono::time_point<std::chrono::steady_clock> m_start_time;
+    std::chrono::time_point<std::chrono::steady_clock> m_last_update;
+    std::chrono::duration<float> m_delta;
+
+public:
+    Time();
+
+    void update();
+
+    std::chrono::duration<float> since_startup() const;
+    std::chrono::duration<float> delta() const;
+
+    float seconds_since_startup() const;
+    float delta_seconds() const;
+};
+
+class TimePlugin : public core::App::Plugin {
+public:
+    void plug(core::App::Builder&) const override;
+};
+
+}
+
+#endif /* F86E20B8_2AFA_4597_AD7A_707E4AEA22BC */

--- a/ige/src/plugin/TimePlugin.cpp
+++ b/ige/src/plugin/TimePlugin.cpp
@@ -1,0 +1,61 @@
+#include "ige/plugin/TimePlugin.hpp"
+#include "ige/core/App.hpp"
+#include "ige/ecs/System.hpp"
+#include "ige/ecs/World.hpp"
+#include <chrono>
+
+using ige::core::App;
+using ige::ecs::System;
+using ige::ecs::World;
+using ige::plugin::time::Time;
+using ige::plugin::time::TimePlugin;
+using std::chrono::steady_clock;
+
+Time::Time()
+    : m_start_time(steady_clock::now())
+    , m_last_update(m_start_time)
+    , m_delta(0)
+{
+}
+
+std::chrono::duration<float> Time::since_startup() const
+{
+    return m_last_update - m_start_time;
+}
+
+std::chrono::duration<float> Time::delta() const
+{
+    return m_delta;
+}
+
+float Time::seconds_since_startup() const
+{
+    return since_startup().count();
+}
+
+float Time::delta_seconds() const
+{
+    return delta().count();
+}
+
+void Time::update()
+{
+    auto now = steady_clock::now();
+    m_delta = now - m_last_update;
+    m_last_update = now;
+}
+
+namespace systems {
+
+static void update_global_time(World& world)
+{
+    world.get_or_emplace<Time>().update();
+}
+
+}
+
+void TimePlugin::plug(App::Builder& builder) const
+{
+    builder.emplace<Time>();
+    builder.add_system(System(systems::update_global_time));
+}


### PR DESCRIPTION
This PR adds a `TimePlugin` along with a `Time` resource. It can be used to conveniently measure the "delta" time elapsed between frames, and the time elapsed since game startup.